### PR TITLE
Change default user to gfdrr

### DIFF
--- a/geonode/layers/management/commands/importlayers.py
+++ b/geonode/layers/management/commands/importlayers.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
             '-u',
             '--user',
             dest="user",
-            default=None,
+            default="gfdrr",
             help="Name of the user account which should own the imported layers"),
         make_option(
             '-i',


### PR DESCRIPTION
Default user when importing layers is preferred to be gfdrr unless otherwise stated.